### PR TITLE
make path to sinon.js absolute

### DIFF
--- a/phantomxhr.js
+++ b/phantomxhr.js
@@ -7,6 +7,7 @@ exports.requests = getAllRequests;
 var page;
 
 function phantomXHRInit(initPage, options){
+	var fs = require('fs');
 
 	var inject = false;
 
@@ -20,7 +21,7 @@ function phantomXHRInit(initPage, options){
     		window.CustomEvent = function(){};
 		});
 
-		inject = initPage.injectJs(options.libraryRoot ? (options.libraryRoot + 'sinon.js') : './node_modules/phantomxhr/sinon.js');
+		inject = initPage.injectJs(options.libraryRoot ? (fs.absolute(options.libraryRoot) + 'sinon.js') : './node_modules/phantomxhr/sinon.js');
 
 		initPage.evaluate(function(){
 


### PR DESCRIPTION
Resolving a module path within ```casperjs/phantomjs``` is a major pain (if at all possible, because a resolver like ```npm``` provides is missing). Particularly ```require```ing the ```npm``` installed/provided sinon module and looking up it's path does not seem to work at all (is there any way to do that?). Turning the ```libraryRoot``` option into an absolute path may alleviate the problems arising from that.

The built-in default ```./node_modules/phantomxhr/sinon.js``` does not work for me either, if running ```PhantomXHR``` through ```grunt-phantomflow``` and ```PhantomFlow```.