### PR TITLE
Array.prototype.reverse() change origin matches array

### DIFF
--- a/phantomxhr.js
+++ b/phantomxhr.js
@@ -153,7 +153,7 @@ function setup(){
 								};
 							}
 
-							window._ajaxmock_.matches.reverse().forEach(function (func) {
+							window._ajaxmock_.matches.slice(0).reverse().forEach(function (func) {
 								anyMatches = anyMatches || func(request.method, request.url);
 							});
 


### PR DESCRIPTION
Hello!
I found a bug in code PhantomXHR. Array.prototype.reverse() not create new instance of array and change origin array. Origin array of matches should not be changed.